### PR TITLE
feat: release major tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release action
-        uses: atomicfi/action-release-action@1.0.1
+        uses: atomicfi/action-release-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -12,8 +12,21 @@ runs:
       with:
         fetch-depth: "0"
     - name: Bump version and push tag
+      id: bump-version
       uses: anothrNick/github-tag-action@1.36.0
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         RELEASE_BRANCHES: main
         WITH_V: true
+    - name: Get major version
+      id: major-version
+      needs: bump-version
+      shell: bash
+      run: |
+        echo "::set-output name=major-version-tag::$(cut -d . -f 1 <<< ${{steps.bump-version.outputs.new_tag}})"
+    - name: Push major tag
+      needs: major-version
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        CUSTOM_TAG: ${{ steps.major-version.outpus.major-version-tag }}


### PR DESCRIPTION
Should now release major version as a separate tag.
A second PR will be created to validate the `v1` tag is updated, after this PR is merged and released.

For PA-105